### PR TITLE
fix-profile-loader

### DIFF
--- a/src/Profile.php
+++ b/src/Profile.php
@@ -37,7 +37,7 @@ class Profile {
 		$profiles = [];
 		foreach (new \DirectoryIterator($profileDir) as $file) {
 			if ($file->isFile() && $loader->supports($file->getFilename())) {
-				$profiles[] = $file->getFilename();
+				$profiles[] = $file->getBasename('.yml');
 			}
 		}
 

--- a/tests/ProfileTest.php
+++ b/tests/ProfileTest.php
@@ -139,4 +139,10 @@ class ProfileTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse($config->getWhitespace('after_open'));
 		$this->assertTrue($config->getWhitespace('before_assignment', 'assignments'));
 	}
+
+	public function testProfileLoader() {
+		$config = new Profile('psr-2');
+		$indentChar = $config->getIndentation('character');
+		$this->assertEquals('space', $indentChar);
+	}
 }


### PR DESCRIPTION
Load profile by profile name without given file extension which has thrown an exception if it was set.