### PR TITLE
Fix Profile class

### DIFF
--- a/src/Profile.php
+++ b/src/Profile.php
@@ -49,7 +49,12 @@ class Profile {
 		return $this->config;
 	}
 
-	public function getIndentation(string $key): string {
+	/**
+	 * @param string $key
+	 *
+	 * @return string|int|bool
+	 */
+	public function getIndentation(string $key) {
 		return $this->config['indentation'][$key] ?? '';
 	}
 

--- a/tests/ProfileTest.php
+++ b/tests/ProfileTest.php
@@ -124,12 +124,15 @@ class ProfileTest extends TestCase {
 		$config = new Profile();
 
 		$this->assertEquals('tab', $config->getIndentation('character'));
+		$this->assertEquals(1, $config->getIndentation('size'));
+		$this->assertEquals('', $config->getIndentation('wrong_key'));
 	}
 
 	public function testBraces(): void {
 		$config = new Profile();
 
 		$this->assertEquals('same', $config->getBraces('struct'));
+		$this->assertEquals('', $config->getBraces('wrong_key'));
 	}
 
 	public function testWhitespace(): void {


### PR DESCRIPTION
Fix `Profile::getIndentation()`: it can return `string`, `int` or `bool` and cannot be typed to `string` only.